### PR TITLE
Add support for custom request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add the library to your module dependencies.
 
 ```groovy
 dependencies {
-    implementation 'com.getdreams:android-sdk:0.7.0'
+    implementation 'com.getdreams:android-sdk:0.8.0-rc.1'
 }
 ```
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        versionName '0.7.0'
+        versionName '0.8.0-rc.1'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/sdk/src/androidTest/assets/index.html
+++ b/sdk/src/androidTest/assets/index.html
@@ -49,6 +49,12 @@
         console.assert(obj.hasOwnProperty('location'), 'missing location');
         return obj.hasOwnProperty('location');
     }
+    function testAjax() {
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', '/testAjax');
+        xhr.setRequestHeader('Content-Type', 'text/plain');
+        xhr.send('Example body');
+    }
     </script>
 </head>
 <body>
@@ -59,5 +65,6 @@
 <button id="provision_account_button" onclick="provisionAccount()">provision account</button>
 <button id="share_button" onclick="share({text: 'text for share' , url:'http://test.url', title : 'testTitle'})">share</button>
 <button id="share_button_null" onclick="share({text: 'text for share' , url:'http://test.url'})">share title null</button>
+<button id="test_ajax_button" onclick="testAjax()">test ajax</button>
 </body>
 </html>

--- a/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
+++ b/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
@@ -47,6 +47,25 @@ interface RequestInterface {
      *
      * @param credentials Credentials used to authenticate the user.
      * @param locale The locale to use in Dreams.
+     * @param headers Custom HTTP headers to be used with initial request.
+     * @param onCompletion Called when [launch] has completed.
+     */
+    fun launch(
+        credentials: Credentials,
+        locale: Locale,
+        headers: Map<String, String> = emptyMap(),
+        onCompletion: OnLaunchCompletion = OnLaunchCompletion {
+            if (it is Result.Failure) {
+                Log.e("Dreams", "Failed to launch due to ${it.error.message}", it.error.cause)
+            }
+        }
+    )
+
+    /**
+     * Launch Dreams.
+     *
+     * @param credentials Credentials used to authenticate the user.
+     * @param locale The locale to use in Dreams.
      * @param location The location that Dreams should navigate to on a successful launch.
      * @param onCompletion Called when [launch] has completed.
      */
@@ -54,6 +73,27 @@ interface RequestInterface {
         credentials: Credentials,
         locale: Locale,
         location: String,
+        onCompletion: OnLaunchCompletion = OnLaunchCompletion {
+            if (it is Result.Failure) {
+                Log.e("Dreams", "Failed to launch due to ${it.error.message}", it.error.cause)
+            }
+        }
+    )
+
+    /**
+     * Launch Dreams.
+     *
+     * @param credentials Credentials used to authenticate the user.
+     * @param locale The locale to use in Dreams.
+     * @param location The location that Dreams should navigate to on a successful launch.
+     * @param headers Custom HTTP headers to be used with initial request.
+     * @param onCompletion Called when [launch] has completed.
+     */
+    fun launch(
+        credentials: Credentials,
+        locale: Locale,
+        location: String,
+        headers: Map<String, String> = emptyMap(),
         onCompletion: OnLaunchCompletion = OnLaunchCompletion {
             if (it is Result.Failure) {
                 Log.e("Dreams", "Failed to launch due to ${it.error.message}", it.error.cause)


### PR DESCRIPTION
Set custom http headers during launch by using:
- ```DreamsView.launch(credentials: Credentials, locale: Locale, headers: Map<String, String>, onCompletion: OnLaunchCompletion)```

Set your own implementation of a [WebViewClient](https://developer.android.com/reference/kotlin/android/webkit/WebViewClient) to customise WebView request behavior (e.g. set headers) by using:
- ```DreamsView.setWebViewClient(client: WebViewClient)```

Note: A simple WebViewClient is implemented [in `customHeaders` test](https://github.com/dreamstechnology/dreams-android-sdk/blob/feature/add-headers-support/sdk/src/androidTest/java/com/getdreams/views/DreamsViewTest.kt#L275). See [this article](https://medium.com/@madmuc/intercept-all-network-traffic-in-webkit-on-android-9c56c9262c85) for insight on edge cases.