### PR TITLE
Add headers support - new approach to match iOS structure

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -9,8 +9,6 @@
           <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,14 @@ allprojects {
         mavenLocal()
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
+        maven {
+            url 'https://maven.pkg.github.com/dreamstechnology/dreams-android-sdk'
+            name = "GitHubPackages"
+            credentials {
+                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USERNAME")
+                password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ allprojects {
         mavenLocal()
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -35,6 +35,9 @@ android {
 
 dependencies {
     implementation project(path: ':sdk')
+//    implementation 'com.getdreams:android-sdk:0.8.0-rc.4'
+
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
     implementation 'androidx.core:core-ktx:1.6.0'

--- a/example-app/src/main/java/com/getdreams/example/MainActivity.kt
+++ b/example-app/src/main/java/com/getdreams/example/MainActivity.kt
@@ -109,9 +109,18 @@ class MainActivity : AppCompatActivity() {
 
         val location = intent?.data?.path
         if (location.isNullOrBlank()) {
-            dreamsView.launch(Credentials("token"), Locale.ENGLISH, onLaunch)
+            dreamsView.launch(
+                credentials = Credentials("token"),
+                locale = Locale.ENGLISH,
+                onCompletion = onLaunch
+            )
         } else {
-            dreamsView.launch(Credentials("token"), Locale.ENGLISH, location, onLaunch)
+            dreamsView.launch(
+                credentials = Credentials("token"),
+                locale = Locale.ENGLISH,
+                location = location,
+                onCompletion = onLaunch
+            )
         }
 
         dreamsView.registerEventListener(listener)

--- a/example-app/src/main/java/com/getdreams/example/MainActivity.kt
+++ b/example-app/src/main/java/com/getdreams/example/MainActivity.kt
@@ -13,6 +13,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import com.getdreams.Credentials
+import com.getdreams.LaunchConfig
 import com.getdreams.Result
 import com.getdreams.connections.EventListener
 import com.getdreams.connections.webview.LaunchError
@@ -41,12 +42,14 @@ class MainActivity : AppCompatActivity() {
                     dreamsView.updateCredentials(requestId = event.requestId, credentials)
                 }
             }
+
             is Event.Telemetry -> {
                 // Convert from JSONObject to Map
                 val params = event.payload?.keys()?.asSequence()?.associate { it to event.payload?.get(it) }
                 // Pass the event on
                 FakeBackend.sendAnalyticsEvent(event.name, params)
             }
+
             is Event.AccountProvisionRequested -> {
                 // Provision an account to the user
                 GlobalScope.launch {
@@ -65,6 +68,7 @@ class MainActivity : AppCompatActivity() {
                     }
                 }
             }
+
             is Event.ExitRequested -> {
                 // We should exit the Dreams context
                 this@MainActivity.finish()
@@ -89,6 +93,7 @@ class MainActivity : AppCompatActivity() {
                     Log.v("ExampleApp", "Launch was successful")
                     dialog.dismiss()
                 }
+
                 is Result.Failure -> {
                     // Something went wrong, handle the error
                     Log.w("ExampleApp", "Launch failed with ${result.error.message}", result.error.cause)
@@ -108,20 +113,19 @@ class MainActivity : AppCompatActivity() {
         }
 
         val location = intent?.data?.path
-        if (location.isNullOrBlank()) {
-            dreamsView.launch(
-                credentials = Credentials("token"),
-                locale = Locale.ENGLISH,
-                onCompletion = onLaunch
-            )
-        } else {
-            dreamsView.launch(
-                credentials = Credentials("token"),
-                locale = Locale.ENGLISH,
-                location = location,
-                onCompletion = onLaunch
-            )
-        }
+        dreamsView.launch(
+            credentials = Credentials("token"),
+            locale = Locale.ENGLISH,
+            headers = mapOf(
+                "someHeader" to "someValue"
+            ),
+            launchConfig = LaunchConfig(
+                location = location?.takeIf { it.isNotBlank() },
+                theme = "myTheme",
+                timezone = "myTimezone",
+            ),
+            onCompletion = onLaunch
+        )
 
         dreamsView.registerEventListener(listener)
     }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        versionName '0.8.0-rc.4'
+        versionName '0.8.0-rc.5'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -50,7 +50,7 @@ dependencies {
 
     // dependencies to intercept webview headers
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
-    implementation 'com.github.acsbendi:Android-Request-Inspector-WebView:1.0.6'
+    implementation 'com.getdreams:requestinspectorwebview:1.0.6'
 
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'androidx.test:core:1.4.0'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        versionName '0.7.0'
+        versionName '0.8.0-rc.2'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -139,12 +139,12 @@ afterEvaluate {
                         url = 'https://dreamstechnology.com/'
                     }
                 }
-
-                signing {
-                    useGpgCmd()
-                    sign publishing.publications.release
-                }
             }
         }
+    }
+
+    signing {
+        useGpgCmd()
+        sign publishing.publications.release
     }
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        versionName '0.8.0-rc.3'
+        versionName '0.8.0-rc.4'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -47,7 +47,10 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation("com.squareup.okhttp3:okhttp:4.9.0")
+
+    // dependencies to intercept webview headers
+    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
+    implementation 'com.github.acsbendi:Android-Request-Inspector-WebView:1.0.6'
 
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'androidx.test:core:1.4.0'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation("com.squareup.okhttp3:okhttp:4.9.0")
 
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'androidx.test:core:1.4.0'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        versionName '0.8.0-rc.2'
+        versionName '0.8.0-rc.3'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        versionName '0.8.0-rc.5'
+        versionName '0.8.0-rc.6'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/sdk/src/androidTest/java/com/getdreams/views/DreamsViewTest.kt
+++ b/sdk/src/androidTest/java/com/getdreams/views/DreamsViewTest.kt
@@ -7,7 +7,6 @@
 package com.getdreams.views
 
 import android.content.Intent
-import android.text.Html
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
@@ -18,6 +17,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import com.getdreams.Credentials
 import com.getdreams.Dreams
+import com.getdreams.LaunchConfig
 import com.getdreams.R
 import com.getdreams.Result
 import com.getdreams.TestActivity
@@ -37,10 +37,10 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import okio.Buffer
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.anything
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
-import org.hamcrest.Matchers.anything
-import org.hamcrest.Matchers.allOf
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -66,9 +66,11 @@ class DreamsViewTest {
                 "/users/verify_token?location=fake_location" -> MockResponse()
                     .setResponseCode(302)
                     .addHeader("Location", server.url("/index").toString())
+
                 "/index" -> MockResponse()
                     .setResponseCode(200)
                     .setBody(Buffer().readFrom(getInputStreamFromAssets("index.html")))
+
                 else -> MockResponse().setResponseCode(404)
             }
         }
@@ -102,7 +104,7 @@ class DreamsViewTest {
             dreamsView.launch(
                 credentials = Credentials("id token"),
                 locale = Locale.CANADA_FRENCH,
-                location = "fake_location",
+                launchConfig = LaunchConfig(location = "fake_location"),
                 onCompletion = onLaunchCompletion
             )
             dreamsView.registerEventListener { event ->
@@ -112,6 +114,7 @@ class DreamsViewTest {
                             latch.countDown()
                         }
                     }
+
                     else -> {
                     }
                 }
@@ -163,6 +166,7 @@ class DreamsViewTest {
                             latch.countDown()
                         }
                     }
+
                     else -> {
                     }
                 }
@@ -367,9 +371,11 @@ class DreamsViewTest {
                 when (event) {
                     is Event.Telemetry -> {
                         if ("content_loaded" == event.name) {
-                            dreamsView.update(mapOf(
-                                "header" to "updatedValue"
-                            ))
+                            dreamsView.update(
+                                mapOf(
+                                    "header" to "updatedValue"
+                                )
+                            )
                             GlobalScope.launch {
                                 delay(250)
                                 latch.countDown()

--- a/sdk/src/main/java/com/getdreams/Diagnostics.kt
+++ b/sdk/src/main/java/com/getdreams/Diagnostics.kt
@@ -1,0 +1,11 @@
+package com.getdreams
+
+import okhttp3.Interceptor
+
+/**
+ * Collection of diagnostic setup.
+ * @param interceptors Interceptors to set when optional headers are set and all internal WebView requests are re-sent using Okhttp client.
+ */
+data class Diagnostics(
+    val interceptors: List<Interceptor>? = null,
+)

--- a/sdk/src/main/java/com/getdreams/LaunchConfig.kt
+++ b/sdk/src/main/java/com/getdreams/LaunchConfig.kt
@@ -1,0 +1,13 @@
+package com.getdreams
+
+/**
+ * Collection of extra data to be passed during launch procedure.
+ * @param location The location that Dreams should navigate to on a successful launch.
+ * @param theme Whether sdk should launch/initialize in light/dark mode.
+ * @param timezone Timezone to provide to sdk during launch/initialize.
+ */
+data class LaunchConfig(
+    val location: String? = null,
+    val theme: String? = null,
+    val timezone: String? = null,
+)

--- a/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
+++ b/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
@@ -73,6 +73,12 @@ interface RequestInterface {
     fun updateLocale(locale: Locale)
 
     /**
+     * This method can be called at all times after the WebView is presented, the Request interface will send the headers with every request.
+     * @param headers Set optional HTTP headers
+     */
+    fun update(headers: Map<String, String>?)
+
+    /**
      * Update the id token.
      *
      * @param requestId The request id of the event that informed that the token was expired.

--- a/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
+++ b/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
@@ -8,6 +8,7 @@ package com.getdreams.connections.webview
 
 import android.util.Log
 import com.getdreams.Credentials
+import com.getdreams.Diagnostics
 import com.getdreams.LaunchConfig
 import java.util.Locale
 import com.getdreams.Result
@@ -83,4 +84,9 @@ interface RequestInterface {
      * @param location Where to navigate to.
      */
     fun navigateTo(location: String)
+
+    /**
+     * Sets diagnostics setup.
+     */
+    fun setDiagnostics(diagnostics: Diagnostics?)
 }

--- a/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
+++ b/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
@@ -8,6 +8,7 @@ package com.getdreams.connections.webview
 
 import android.util.Log
 import com.getdreams.Credentials
+import com.getdreams.LaunchConfig
 import java.util.Locale
 import com.getdreams.Result
 
@@ -30,34 +31,15 @@ interface RequestInterface {
      *
      * @param credentials Credentials used to authenticate the user.
      * @param locale The locale to use in Dreams.
-     * @param headers Set optional HTTP headers
+     * @param headers Set optional HTTP headers.
+     * @param launchConfig Optional launch configuration.
      * @param onCompletion Called when [launch] has completed.
      */
     fun launch(
         credentials: Credentials,
         locale: Locale,
         headers: Map<String, String>? = null,
-        onCompletion: OnLaunchCompletion = OnLaunchCompletion {
-            if (it is Result.Failure) {
-                Log.e("Dreams", "Failed to launch due to ${it.error.message}", it.error.cause)
-            }
-        }
-    )
-
-    /**
-     * Launch Dreams.
-     *
-     * @param credentials Credentials used to authenticate the user.
-     * @param locale The locale to use in Dreams.
-     * @param headers Set optional HTTP headers
-     * @param location The location that Dreams should navigate to on a successful launch.
-     * @param onCompletion Called when [launch] has completed.
-     */
-    fun launch(
-        credentials: Credentials,
-        locale: Locale,
-        headers: Map<String, String>? = null,
-        location: String,
+        launchConfig: LaunchConfig = LaunchConfig(),
         onCompletion: OnLaunchCompletion = OnLaunchCompletion {
             if (it is Result.Failure) {
                 Log.e("Dreams", "Failed to launch due to ${it.error.message}", it.error.cause)

--- a/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
+++ b/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
@@ -30,11 +30,13 @@ interface RequestInterface {
      *
      * @param credentials Credentials used to authenticate the user.
      * @param locale The locale to use in Dreams.
+     * @param headers Set optional HTTP headers
      * @param onCompletion Called when [launch] has completed.
      */
     fun launch(
         credentials: Credentials,
         locale: Locale,
+        headers: Map<String, String>? = null,
         onCompletion: OnLaunchCompletion = OnLaunchCompletion {
             if (it is Result.Failure) {
                 Log.e("Dreams", "Failed to launch due to ${it.error.message}", it.error.cause)
@@ -47,12 +49,14 @@ interface RequestInterface {
      *
      * @param credentials Credentials used to authenticate the user.
      * @param locale The locale to use in Dreams.
+     * @param headers Set optional HTTP headers
      * @param location The location that Dreams should navigate to on a successful launch.
      * @param onCompletion Called when [launch] has completed.
      */
     fun launch(
         credentials: Credentials,
         locale: Locale,
+        headers: Map<String, String>? = null,
         location: String,
         onCompletion: OnLaunchCompletion = OnLaunchCompletion {
             if (it is Result.Failure) {

--- a/sdk/src/main/java/com/getdreams/views/DreamsView.kt
+++ b/sdk/src/main/java/com/getdreams/views/DreamsView.kt
@@ -21,6 +21,7 @@ import android.widget.FrameLayout
 import com.acsbendi.requestinspectorwebview.RequestInspectorWebViewClient
 import com.acsbendi.requestinspectorwebview.WebViewRequest
 import com.getdreams.Credentials
+import com.getdreams.Diagnostics
 import com.getdreams.Dreams
 import com.getdreams.LaunchConfig
 import com.getdreams.R
@@ -86,6 +87,7 @@ class DreamsView : FrameLayout, DreamsViewInterface {
     private val webView: WebView
     private val responseListeners = CopyOnWriteArrayList<EventListener>()
     private var headers: Map<String, String>? = null
+    private var diagnostics: Diagnostics? = null
 
     private class WebkitCookieManager(private val cookieManager: CookieManager) : CookieJar {
 
@@ -150,6 +152,11 @@ class DreamsView : FrameLayout, DreamsViewInterface {
                         val cookieManager = CookieManager.getInstance()
                         val httpClient = OkHttpClient.Builder()
                             .cookieJar(WebkitCookieManager(cookieManager))
+                            .apply {
+                                diagnostics?.interceptors?.forEach {
+                                    addInterceptor(it)
+                                }
+                            }
                             .build()
                         // build headers
                         val headersBuilder = Headers.Builder()
@@ -548,5 +555,9 @@ class DreamsView : FrameLayout, DreamsViewInterface {
 
     override fun goBack() {
         webView.goBack()
+    }
+
+    override fun setDiagnostics(diagnostics: Diagnostics?) {
+        this.diagnostics = diagnostics
     }
 }

--- a/sdk/src/main/java/com/getdreams/views/DreamsView.kt
+++ b/sdk/src/main/java/com/getdreams/views/DreamsView.kt
@@ -281,6 +281,7 @@ class DreamsView : FrameLayout, DreamsViewInterface {
     private fun verifyTokenRequest(
         uri: Uri,
         jsonBody: JSONObject,
+        headers: Map<String, String>?,
         launchConfig: LaunchConfig,
     ): Result<InitResponse, LaunchError> {
         val uriBuilder = uri.buildUpon()
@@ -307,6 +308,9 @@ class DreamsView : FrameLayout, DreamsViewInterface {
             requestMethod = "POST"
             setRequestProperty("Content-Type", "application/json; utf-8")
             setRequestProperty("Accept", "application/json")
+            headers?.forEach {
+                setRequestProperty(it.key, it.value)
+            }
             doOutput = true
             doInput = false
             instanceFollowRedirects = false
@@ -367,6 +371,7 @@ class DreamsView : FrameLayout, DreamsViewInterface {
         clientId: String,
         idToken: String,
         localeIdentifier: String,
+        headers: Map<String, String>?,
         launchConfig: LaunchConfig,
     ): Result<String, LaunchError> {
         val jsonBody = JSONObject()
@@ -377,6 +382,7 @@ class DreamsView : FrameLayout, DreamsViewInterface {
             verifyTokenRequest(
                 Dreams.instance.baseUri,
                 jsonBody,
+                headers,
                 launchConfig,
             )
         }
@@ -420,7 +426,7 @@ class DreamsView : FrameLayout, DreamsViewInterface {
 
         GlobalScope.launch {
             when (val result =
-                initializeWebApp(Dreams.instance.clientId, credentials.idToken, languageTag, launchConfig)) {
+                initializeWebApp(Dreams.instance.clientId, credentials.idToken, languageTag, headers, launchConfig)) {
                 is Result.Success -> {
                     withContext(Dispatchers.Main) {
                         webView.loadUrlWithOptionalHeaders(result.value, headers)


### PR DESCRIPTION
Set custom http headers during launch by using this functions on DreamsView (RequestInterface):


    /**
     * Launch Dreams.
     *
     * @param credentials Credentials used to authenticate the user.
     * @param locale The locale to use in Dreams.
     * @param headers Set optional HTTP headers
     * @param onCompletion Called when [launch] has completed.
     */
    fun launch(
        credentials: Credentials,
        locale: Locale,
        headers: Map<String, String>? = null,
        onCompletion: OnLaunchCompletion = OnLaunchCompletion {
            if (it is Result.Failure) {
                Log.e("Dreams", "Failed to launch due to ${it.error.message}", it.error.cause)
            }
        }
    )

    /**
     * Launch Dreams.
     *
     * @param credentials Credentials used to authenticate the user.
     * @param locale The locale to use in Dreams.
     * @param headers Set optional HTTP headers
     * @param location The location that Dreams should navigate to on a successful launch.
     * @param onCompletion Called when [launch] has completed.
     */
    fun launch(
        credentials: Credentials,
        locale: Locale,
        headers: Map<String, String>? = null,
        location: String,
        onCompletion: OnLaunchCompletion = OnLaunchCompletion {
            if (it is Result.Failure) {
                Log.e("Dreams", "Failed to launch due to ${it.error.message}", it.error.cause)
            }
        }
    )

And update them afterwards with function on DreamsView (RequestInterface):

    /**
     * This method can be called at all times after the WebView is presented, the Request interface will send the headers with every request.
     * @param headers Set optional HTTP headers
     */
    fun update(headers: Map<String, String>?)
    
Also signing process should be fixed and GPG should be used for signing (if it is properly setup in publishing workflow).
